### PR TITLE
chore: redirect to app upon authentication

### DIFF
--- a/src/app/auth.tsx
+++ b/src/app/auth.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect } from "react";
+import { ActivityIndicator } from "react-native";
 import Button from "@src/components/ui/Button";
 import Center from "@src/components/ui/Center";
 import Stack from "@src/components/ui/Stack";
@@ -6,19 +7,11 @@ import { Text } from "@src/components/ui/typography";
 import { useGlobalSearchParams, router } from "expo-router";
 import { SafeAreaView } from "react-native";
 import useAuth from "@src/components/hooks/useAuth";
+import { googleAuth } from "@src/services/authApi";
+import { theme } from "@src/styles/theme";
 
 type AuthParams = {
-  _id: string;
   name: string;
-  email: string;
-  preferred_mode: string;
-  daily_goal: string;
-  level: string;
-  is_setup_complete: string;
-  xp: string;
-  hp: string;
-  device_id: string;
-  provider_id: string;
   token: string;
 };
 
@@ -28,14 +21,18 @@ const AuthCallback = () => {
   const { handleGoogleAuthCallback } = useAuth();
 
   useEffect(() => {
-    if (params && params._id && params.token) {
-      const completeSignIn = async () => {
-        await handleGoogleAuthCallback(params as any);
+    if (params?.token) {
+      googleAuth(params.token as string).then(async (res) => {
+        params.name = res.name;
+        const completeSignIn = async () => {
+          await handleGoogleAuthCallback(res as any);
+          setTimeout(() => {
+            router.navigate("/");
+          }, 1000);
+        };
 
-        router.navigate("/");
-      };
-
-      completeSignIn();
+        completeSignIn();
+      });
     }
   }, [params]);
 
@@ -46,16 +43,22 @@ const AuthCallback = () => {
   return (
     <SafeAreaView style={{ flex: 1 }}>
       <Center p={30} flex={1}>
-        <Stack flexDirection="column" gap={30}>
-          <Text level="title_1" align="center">
-            Welcome {params?.name}!
-          </Text>
-          <Button
-            title="Yey! Continue"
-            onPress={handleContinuePress}
-            variant="primary"
-          />
-        </Stack>
+        {params?.name ? (
+          <Stack flexDirection="column" gap={30}>
+            <Text level="title_1" align="center">
+              Welcome {params?.name}!
+            </Text>
+            <Button
+              title="Yey! Continue"
+              onPress={handleContinuePress}
+              variant="primary"
+            />
+          </Stack>
+        ) : (
+          <Stack flexDirection="column" gap={30}>
+            <ActivityIndicator size="large" color={theme.colors.primary[500]} />
+          </Stack>
+        )}
       </Center>
     </SafeAreaView>
   );

--- a/src/services/authApi.tsx
+++ b/src/services/authApi.tsx
@@ -1,0 +1,11 @@
+import config from "@src/config";
+import axios from "axios";
+
+export const googleAuth = async (code: string) => {
+  const {
+    data: { data },
+  } = await axios.get(
+    `${config.api_url}/auth/google/callback/?code=${encodeURIComponent(code)}`,
+  );
+  return data;
+};


### PR DESCRIPTION
**Includes:** 
Redirection to app after authentication

**Does not include:**
Opening the authentication url in webview. This is not allowed by Google:
![image](https://github.com/LangaraBeetles/weaup-react-native-app/assets/26020262/62f463aa-2c70-4f99-b06a-17f56b65bc1d)

https://support.google.com/accounts/answer/12917337?hl=en#zippy=%2Cdisallowed-useragent

**To test:**
1. Use [this branch](https://github.com/LangaraBeetles/weaup-api/tree/CU-86b15rm6c_Google-Auth-WebView) to run the API locally.
2. Update the GOOGLE_REDIRECT_URI on the .env file. Please refer to [Environment Variables](https://app.clickup.com/9014337553/v/dc/8cmqr0h-954/8cmqr0h-1114)
3. Update **config.ts** and set **api_url** to http://[**your IP**]:3000/api/v1