### PR TITLE
fix: score layout for diferent screen sizes

### DIFF
--- a/src/components/homepage/ScoreComponent.tsx
+++ b/src/components/homepage/ScoreComponent.tsx
@@ -5,6 +5,9 @@ import Icon from "../ui/Icon";
 import { Text } from "../ui/typography";
 import { useUser } from "@src/state/useUser";
 import Divider from "../ui/Divider";
+import { Dimensions } from "react-native";
+
+const { width } = Dimensions.get("screen");
 
 const ScoreComponent = () => {
   const userHP = useUser((state) => state.user.hp);
@@ -27,8 +30,10 @@ const ScoreComponent = () => {
           flexDirection="row"
           border={1}
           borderRadius={20}
-          px={20}
+          pl={20}
+          pr={width * 0.1}
           py={16}
+          h={90}
           w="100%"
           justifyContent="space-between"
           borderColor={theme.colors.neutral[100]}


### PR DESCRIPTION
<img width="411" alt="Screenshot 2024-07-25 at 11 07 31 PM" src="https://github.com/user-attachments/assets/92002896-73d6-4506-b062-b4690ed5e6e4">


Score card according to issue 114