### PR TITLE
fix: align pils and user card

### DIFF
--- a/src/app/(tabs)/index.tsx
+++ b/src/app/(tabs)/index.tsx
@@ -97,6 +97,7 @@ const HomePage = () => {
           justifyContent="space-between"
           p={15}
           pb={0}
+          alignItems="center"
         >
           <Stack
             flexDirection="row"


### PR DESCRIPTION
<img width="411" alt="Screenshot 2024-07-25 at 11 11 45 PM" src="https://github.com/user-attachments/assets/f8c2ad42-1012-4028-95e0-dc235971e5b4">


Issue 113, align on home page of pils