### PR TITLE
CU 86b1e6xcb: Display badge after join challenge notification

### DIFF
--- a/src/app/challenges/challenge-details.tsx
+++ b/src/app/challenges/challenge-details.tsx
@@ -6,7 +6,7 @@ import {
   ScrollView,
   Platform,
 } from "react-native";
-import { router, useLocalSearchParams, usePathname } from "expo-router";
+import { useLocalSearchParams, usePathname } from "expo-router";
 import { useQuery } from "@tanstack/react-query";
 
 import { Text } from "@src/components/ui/typography";
@@ -52,8 +52,6 @@ const ChallengeDetail = () => {
           : urlWithUserId;
 
       await Share.share({ message });
-      //INFO: pretend to earn badge
-      router.push({ pathname: "/earn-badge", params: { badgeId: 2 } });
     } catch (error) {
       console.log(error);
     }

--- a/src/components/forms/ChallengeInvitationForm.tsx
+++ b/src/components/forms/ChallengeInvitationForm.tsx
@@ -14,7 +14,6 @@ import { ChallengeInputType } from "@src/interfaces/challenge.types";
 import { useFormContext } from "react-hook-form";
 import { BottomSheetModal } from "@gorhom/bottom-sheet";
 import { Share } from "react-native";
-import { router } from "expo-router";
 import { useUser } from "@root/src/state/useUser";
 import getShareChallengeLink from "@root/src/utils/share-challenge-link";
 
@@ -66,8 +65,6 @@ const ChallengeInvitationForm = (props: {
         message,
       });
       setHasShared(true);
-      //INFO: pretend earn badge
-      router.push({ pathname: "/earn-badge", params: { badgeId: 2 } });
     } catch (error: any) {
       console.log(error.message);
     }

--- a/src/components/providers/PushNotificationsProvider.tsx
+++ b/src/components/providers/PushNotificationsProvider.tsx
@@ -171,6 +171,8 @@ const PushNotificationsProvider: React.FC<{ children: React.ReactNode }> = ({
                   return ch;
                 });
               });
+              //INFO: pretend to earn badge
+              router.push({ pathname: "/earn-badge", params: { badgeId: 2 } });
             }
           } catch (error) {
             console.log(error);


### PR DESCRIPTION
**Changes:**
* removed earn badge from share challenge during create
* removed earn badge from share challenge on challenge details
* added earn badge in push notification if category is joined_challenge
* remove unused libraries

**Steps in video:**
1. Login as Beck. 
2. Open challenge. Click share (this part is not visible in the recording).
3. On another device, open link using Langara Beetles account.

https://github.com/user-attachments/assets/3156cfe6-a658-42e8-b180-0ddec7caaebe

